### PR TITLE
Change default connectivity check URL from google to f-droid

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -235,7 +235,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         EditTextPreference pref_ttl = (EditTextPreference) screen.findPreference("ttl");
         pref_dns1.setTitle(getString(R.string.setting_dns, prefs.getString("dns", "-")));
         pref_dns2.setTitle(getString(R.string.setting_dns, prefs.getString("dns2", "-")));
-        pref_validate.setTitle(getString(R.string.setting_validate, prefs.getString("validate", "www.google.com")));
+        pref_validate.setTitle(getString(R.string.setting_validate, prefs.getString("validate", "www.f-droid.org")));
         pref_ttl.setTitle(getString(R.string.setting_ttl, prefs.getString("ttl", "259200")));
 
         // SOCKS5 parameters
@@ -679,7 +679,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             ServiceSinkhole.reload("changed " + name, this, false);
 
         } else if ("validate".equals(name)) {
-            String host = prefs.getString(name, "www.google.com");
+            String host = prefs.getString(name, "www.f-droid.org");
             try {
                 checkDomain(host);
                 prefs.edit().putString(name, host.trim()).apply();
@@ -690,7 +690,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                     Toast.makeText(ActivitySettings.this, ex.toString(), Toast.LENGTH_LONG).show();
             }
             getPreferenceScreen().findPreference(name).setTitle(
-                    getString(R.string.setting_validate, prefs.getString(name, "www.google.com")));
+                    getString(R.string.setting_validate, prefs.getString(name, "www.f-droid.org")));
             ServiceSinkhole.reload("changed " + name, this, false);
 
         } else if ("ttl".equals(name))

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2188,7 +2188,7 @@ public class ServiceSinkhole extends VpnService implements SharedPreferences.OnS
                 }
 
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
-                String host = prefs.getString("validate", "www.google.com");
+                String host = prefs.getString("validate", "www.f-droid.org");
                 Log.i(TAG, "Validating " + network + " " + ni + " host=" + host);
 
                 Socket socket = null;

--- a/app/src/main/res/xml-v14/preferences.xml
+++ b/app/src/main/res/xml-v14/preferences.xml
@@ -229,7 +229,7 @@
                 android:inputType="text"
                 android:key="dns2" />
             <EditTextPreference
-                android:hint="www.google.com"
+                android:hint="www.f-droid.org"
                 android:inputType="text"
                 android:key="validate"
                 android:summary="@string/summary_validate" />

--- a/app/src/main/res/xml-v21/preferences.xml
+++ b/app/src/main/res/xml-v21/preferences.xml
@@ -186,7 +186,7 @@
                 android:inputType="text"
                 android:key="dns2" />
             <EditTextPreference
-                android:hint="www.google.com"
+                android:hint="www.f-droid.org"
                 android:inputType="text"
                 android:key="validate"
                 android:summary="@string/summary_validate" />


### PR DESCRIPTION
Since it's a privacy-focused app, I'd say having to query Google repeatedly wouldn't be such a good idea.

Signed-off-by: Atrate <Atrate@protonmail.com>