### PR TITLE
Change VPN interface subnet to prevent conflicts

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityLog.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityLog.java
@@ -123,7 +123,7 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
         lvLog.setAdapter(adapter);
 
         try {
-            vpn4 = InetAddress.getByName(prefs.getString("vpn4", "10.1.10.1"));
+            vpn4 = InetAddress.getByName(prefs.getString("vpn4", "10.213.213.1"));
             vpn6 = InetAddress.getByName(prefs.getString("vpn6", "fd00:1:fd00:1:fd00:1:fd00:1"));
         } catch (UnknownHostException ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -187,7 +187,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         });
 
         // VPN parameters
-        screen.findPreference("vpn4").setTitle(getString(R.string.setting_vpn4, prefs.getString("vpn4", "10.1.10.1")));
+        screen.findPreference("vpn4").setTitle(getString(R.string.setting_vpn4, prefs.getString("vpn4", "10.213.213.1")));
         screen.findPreference("vpn6").setTitle(getString(R.string.setting_vpn6, prefs.getString("vpn6", "fd00:1:fd00:1:fd00:1:fd00:1")));
         EditTextPreference pref_dns1 = (EditTextPreference) screen.findPreference("dns");
         EditTextPreference pref_dns2 = (EditTextPreference) screen.findPreference("dns2");
@@ -531,7 +531,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                     Toast.makeText(ActivitySettings.this, ex.toString(), Toast.LENGTH_LONG).show();
             }
             getPreferenceScreen().findPreference(name).setTitle(
-                    getString(R.string.setting_vpn4, prefs.getString(name, "10.1.10.1")));
+                    getString(R.string.setting_vpn4, prefs.getString(name, "10.213.213.1")));
             ServiceSinkhole.reload("changed " + name, this, false);
 
         } else if ("vpn6".equals(name)) {

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -109,7 +109,7 @@ public class AdapterLog extends CursorAdapter {
             dns1 = (lstDns.size() > 0 ? lstDns.get(0) : null);
             dns2 = (lstDns.size() > 1 ? lstDns.get(1) : null);
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-            vpn4 = InetAddress.getByName(prefs.getString("vpn4", "10.1.10.1"));
+            vpn4 = InetAddress.getByName(prefs.getString("vpn4", "10.213.213.1"));
             vpn6 = InetAddress.getByName(prefs.getString("vpn6", "fd00:1:fd00:1:fd00:1:fd00:1"));
         } catch (UnknownHostException ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1296,7 +1296,7 @@ public class ServiceSinkhole extends VpnService {
             builder.setMetered(Util.isMeteredNetwork(this));
 
         // VPN address
-        String vpn4 = prefs.getString("vpn4", "10.1.10.1");
+        String vpn4 = prefs.getString("vpn4", "10.213.213.1");
         Log.i(TAG, "Using VPN4=" + vpn4);
         builder.addAddress(vpn4, 32);
         if (ip6) {

--- a/app/src/main/jni/netguard/dhcp.c
+++ b/app/src/main/jni/netguard/dhcp.c
@@ -48,15 +48,15 @@ int check_dhcp(const struct arguments *args, const struct udp_session *u,
     log_android(ANDROID_LOG_WARN, "DHCP opcode", request->opcode);
 
     // Discover: source 0.0.0.0:68 destination 255.255.255.255:67
-    // Offer: source 10.1.10.1:67 destination 255.255.255.255:68
+    // Offer: source 10.213.213.1:67 destination 255.255.255.255:68
     // Request: source 0.0.0.0:68 destination 255.255.255.255:67
-    // Ack: source: 10.1.10.1 destination: 255.255.255.255
+    // Ack: source: 10.213.213.1 destination: 255.255.255.255
 
     if (request->opcode == 1) { // Discover/request
         struct dhcp_packet *response = ng_calloc(500, 1, "dhcp");
 
         // Hack
-        inet_pton(AF_INET, "10.1.10.1", (void *) &u->saddr);
+        inet_pton(AF_INET, "10.213.213.1", (void *) &u->saddr);
 
         /*
         Discover:
@@ -77,7 +77,7 @@ int check_dhcp(const struct arguments *args, const struct udp_session *u,
         response->flags = 0;
         memset(&response->ciaddr, 0, sizeof(response->ciaddr));
         inet_pton(AF_INET, "10.1.10.2", &response->yiaddr);
-        inet_pton(AF_INET, "10.1.10.1", &response->siaddr);
+        inet_pton(AF_INET, "10.213.213.1", &response->siaddr);
         memset(&response->giaddr, 0, sizeof(response->giaddr));
 
         // https://tools.ietf.org/html/rfc2132
@@ -105,7 +105,7 @@ int check_dhcp(const struct arguments *args, const struct udp_session *u,
 
         *(options + idx++) = 3; // gateway
         *(options + idx++) = 4; // IP4 length
-        inet_pton(AF_INET, "10.1.10.1", options + idx);
+        inet_pton(AF_INET, "10.213.213.1", options + idx);
         idx += 4;
 
         *(options + idx++) = 51; // lease time
@@ -115,7 +115,7 @@ int check_dhcp(const struct arguments *args, const struct udp_session *u,
 
         *(options + idx++) = 54; // DHCP
         *(options + idx++) = 4; // IP4 length
-        inet_pton(AF_INET, "10.1.10.1", options + idx);
+        inet_pton(AF_INET, "10.213.213.1", options + idx);
         idx += 4;
 
         *(options + idx++) = 6; // DNS

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -140,7 +140,7 @@
                 android:title="@string/setting_forwarding" />
             <EditTextPreference
                 inputType="phone"
-                android:hint="10.1.10.1"
+                android:hint="10.213.213.1"
                 android:inputType="phone"
                 android:key="vpn4" />
             <EditTextPreference


### PR DESCRIPTION
This changes the VPN interface's subnet from 10.1.10.1/24 to 10.213.213.1/24 to prevent conflicts for those who use trackercontrol on a network which uses 10.1.10.1/24

Fixes #159 