### PR TITLE
Add description to app icon button

### DIFF
--- a/app/src/main/res/layout/rule.xml
+++ b/app/src/main/res/layout/rule.xml
@@ -15,6 +15,7 @@
         android:layout_height="40dp"
         android:layout_marginTop="16dp"
         android:scaleType="centerInside"
+        android:contentDescription="@string/tracked_app_icon"
         android:src="@drawable/ic_rocket" />
 
     <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -275,6 +275,7 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     </string-array>
 
     <!-- App Overview -->
+    <string name="tracked_app_icon">Disable internet access for this application</string>
     <string name="tracked_app_name">Application Name</string>
     <plurals name="n_companies_found_week">
         <item quantity="one">contacted %d company last week</item>


### PR DESCRIPTION
Original issue: The app list shows an app icon followed by it's name and sometimes some information thing. The app icon is a button. If you click on it, you disable internet access for that application. The problem is that the button is not labeled. A blind user can not hear what it is and what it does.

Fixed by: adding a content description for the app icons.